### PR TITLE
Add website and release-on-repo to pipelines

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,7 +185,7 @@ jobs:
           allowUpdates: true
           tag: ${{ env.VERSION }}
           commit: actions 
-          artifacts: [macOS dmg, Windows Installer]
+          artifacts: "macOS dmg, Windows Installer"
 
       - name: Modify website pages
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
           artifacts: target/HandWriter.dmg 
           token: ${{ secrets.GITHUB_TOKEN }}
           allowUpdates: true
-          tag: $VERSION
+          tag: ${{ env.VERSION }}
           commit: actions
 
   Windows-release:
@@ -65,7 +65,7 @@ jobs:
           artifacts: target/HandWriter.dmg 
           token: ${{ secrets.GITHUB_TOKEN }}
           allowUpdates: true
-          tag: $Env:VERSION
+          tag: ${{ env.VERSION }}
           commit: actions
 
   Debian-release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,9 @@ name: Release
 
 on:
   push:
-    branches: [actions]
+    branches: [master]
+    tags:
+      - '*'
 
 jobs:
   macOS-release:
@@ -184,19 +186,19 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           allowUpdates: true
           tag: ${{ env.VERSION }}
-          commit: actions 
+          commit: master 
           artifacts: "macOS dmg, Windows Installer"
 
       - name: Modify website pages
         run: |
           # Cloning the website repo
-          git clone git@github.com:SaurusXI/HandWriter-webpage.git
-          cd HandWriter-webpage
+          git clone git@github.com:GDGVIT/handwriter-website.git
+          cd handwriter-website
           sed 's/{VERSION}/'"${{ env.VERSION }}"'/' templates/home.md > content/installer/home.md
           
       - name: Push changes to website repo
         run: |
-          cd HandWriter-webpage
+          cd handwriter-website
           git add content/installer/
           git commit -m "Automated website build for upstream package update"
           git push --force

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -196,6 +196,7 @@ jobs:
           
       - name: Push changes to website repo
         run: |
+          cd HandWriter-webpage
           git add content/installer/
           git commit -m "Automated website build for upstream package update"
           git push --force

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,6 @@ name: Release
 on:
   push:
     branches: [actions]
-    tags: '*'
 
 jobs:
   macOS-release:
@@ -15,7 +14,7 @@ jobs:
         with:
           python-version: "3.6"
 
-      - name: Setup release environment
+      - name: Setup build environment
         run: |
           pip install -r requirements.txt
           brew install expect
@@ -31,14 +30,11 @@ jobs:
       - name: Build Installer
         run: /usr/bin/expect .github/scripts/mac/release.sh
 
-      - name: Release
-        uses: ncipollo/release-action@v1
+      - name: Export setup dmg as .zip artifact
+        uses: actions/upload-artifact@v1
         with:
-          artifacts: target/HandWriter.dmg 
-          token: ${{ secrets.GITHUB_TOKEN }}
-          allowUpdates: true
-          tag: ${{ env.VERSION }}
-          commit: actions
+          name: macOS dmg
+          path: target/HandWriter.dmg
 
   Windows-release:
     runs-on: [windows-latest]
@@ -49,24 +45,21 @@ jobs:
         with:
           python-version: "3.6"
 
-      - name: Setup release environment
+      - name: Setup build environment
         run: |
           pip install pywin32
           pip install -r requirements.txt
           echo "::set-env name=VERSION::$(type version)"
     
-      - name: Build Installer
+      - name: Release
         run: |
           python .\.github\scripts\windows\release.py
 
-      - name: Release
-        uses: ncipollo/release-action@v1
+      - name: Export installer as .zip artifact
+        uses: actions/upload-artifact@v1
         with:
-          artifacts: target/HandWriter.dmg 
-          token: ${{ secrets.GITHUB_TOKEN }}
-          allowUpdates: true
-          tag: ${{ env.VERSION }}
-          commit: actions
+          name: Windows Installer
+          path: target/HandWriterSetup.exe
 
   Debian-release:
     runs-on: [ubuntu-latest]
@@ -160,3 +153,49 @@ jobs:
         run: |
           chmod a+x .github/scripts/fedora/release.sh
           .github/scripts/fedora/release.sh
+
+  Publish:
+    runs-on: [ubuntu-latest]
+    needs: [macOS-release, Windows-release]
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: webfactory/ssh-agent@v0.2.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+
+      - uses: actions/download-artifact@v2
+        with:
+          name: macOS dmg
+
+      - uses: actions/download-artifact@v2
+        with:
+          name: Windows Installer
+
+      - name: Setup release environment
+        run: |
+          echo "::set-env name=VERSION::$(cat version)"
+          git config --global user.name ${{ secrets.GIT_USER }}
+          git config --global user.email ${{ secrets.GIT_EMAIL }}
+          
+      - name: Release
+        uses: ncipollo/release-action@v1
+        with: 
+          token: ${{ secrets.GITHUB_TOKEN }}
+          allowUpdates: true
+          tag: ${{ env.VERSION }}
+          commit: actions 
+          artifacts: [macOS dmg, Windows Installer]
+
+      - name: Modify website pages
+        run: |
+          # Cloning the website repo
+          git clone git@github.com:SaurusXI/HandWriter-webpage.git
+          cd HandWriter-webpage
+          sed 's/{VERSION}/'"${{ env.VERSION }}"'/' templates/home.md > content/installer/home.md
+          
+      - name: Push changes to website repo
+        run: |
+          git add content/installer/
+          git commit -m "Automated website build for upstream package update"
+          git push --force

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,8 @@ name: Release
 
 on:
   push:
-    branches: [master]
+    branches: [actions]
+    tags: '*'
 
 jobs:
   macOS-release:
@@ -27,14 +28,17 @@ jobs:
           FBS_PASS: ${{ secrets.FBS_PASS }}
           GPG_PASS: ${{ secrets.GPG_PASS }}
 
-      - name: Release
+      - name: Build Installer
         run: /usr/bin/expect .github/scripts/mac/release.sh
 
-      - name: Export setup dmg as .zip artifact
-        uses: actions/upload-artifact@v1
+      - name: Release
+        uses: ncipollo/release-action@v1
         with:
-          name: macOS dmg
-          path: target/HandWriter.dmg
+          artifacts: target/HandWriter.dmg 
+          token: ${{ secrets.GITHUB_TOKEN }}
+          allowUpdates: true
+          tag: $VERSION
+          commit: actions
 
   Windows-release:
     runs-on: [windows-latest]
@@ -51,15 +55,18 @@ jobs:
           pip install -r requirements.txt
           echo "::set-env name=VERSION::$(type version)"
     
-      - name: Release
+      - name: Build Installer
         run: |
           python .\.github\scripts\windows\release.py
 
-      - name: Export installer as .zip artifact
-        uses: actions/upload-artifact@v1
+      - name: Release
+        uses: ncipollo/release-action@v1
         with:
-          name: Windows Installer
-          path: target/HandWriterSetup.exe
+          artifacts: target/HandWriter.dmg 
+          token: ${{ secrets.GITHUB_TOKEN }}
+          allowUpdates: true
+          tag: $Env:VERSION
+          commit: actions
 
   Debian-release:
     runs-on: [ubuntu-latest]


### PR DESCRIPTION
- Create a release on the GDGVIT repo every time code is pushed to master based on the contents of version file
- Trigger a rebuild of the website (GDGVIT/handwriter-website) to reflect the release version